### PR TITLE
NOSTORY: flexibility to provide external policy arn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - ...
 
+## [1.0.3] - 2022-07-21
+### Changes
+- feat: Added an option to add external policy arn for `aws_iam_policy_attachment` resource
+
 ## [1.0.2] - 2022-07-15
 ### Description
 - fix: Create policy attachment only when users/groups/roles are provided
@@ -31,8 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/boldlink/terraform-aws-iam-policy/compare/1.0.1...HEAD
 
+[1.0.3]: https://github.com/boldlink/terraform-aws-iam-policy/releases/tag/1.0.3
 [1.0.2]: https://github.com/boldlink/terraform-aws-iam-policy/releases/tag/1.0.2
-
 [1.0.1]: https://github.com/boldlink/terraform-aws-iam-policy/releases/tag/1.0.1
-
 [1.0.0]: https://github.com/boldlink/terraform-aws-iam-policy/releases/tag/1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added: `.github/workflow` folder
 - Added: `.gitignore` file
 - added:  Complete and minimum examples
+- feat: Added an option to add external policy arn for `aws_iam_policy_attachment` resource
 
 ## [1.0.1] - 2022-04-28
 ### Description

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ No modules.
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. | `string` | `null` | no |
 | <a name="input_path"></a> [path](#input\_path) | (Optional, default `/`) Path in which to create the policy. | `string` | `null` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | (Required) The policy document. This is a JSON formatted string. | `string` | n/a | yes |
+| <a name="input_policy_arn"></a> [policy\_arn](#input\_policy\_arn) | (Optional) ARN of an external policy not created by this module | `string` | `null` | no |
 | <a name="input_policy_attachment_name"></a> [policy\_attachment\_name](#input\_policy\_attachment\_name) | (Optional) - The name of the attachment. Required when users, roles or groups are provided. | `string` | `null` | no |
 | <a name="input_policy_name"></a> [policy\_name](#input\_policy\_name) | (Optional, Forces new resource) The name of the policy. If omitted, Terraform will assign a random, unique name. | `string` | `null` | no |
 | <a name="input_roles"></a> [roles](#input\_roles) | (Optional) - The role(s) the policy should be applied to | `list(string)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -16,5 +16,5 @@ resource "aws_iam_policy_attachment" "main" {
   users      = var.users
   roles      = var.roles
   groups     = var.groups
-  policy_arn = aws_iam_policy.main.arn
+  policy_arn = var.policy_arn != null ? var.policy_arn : aws_iam_policy.main.arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "path" {
   default     = null
 }
 
+variable "policy_arn" {
+  type        = string
+  description = "(Optional) ARN of an external policy not created by this module"
+  default     = null
+}
+
 variable "policy" {
   type        = string
   description = "(Required) The policy document. This is a JSON formatted string."


### PR DESCRIPTION
# Description

The purpose of this PR is to add the flexibility to provide an external policy arn 
## Features/Fixes/Patches/Changes list:

Please check the [v1.0.3 CHANGELOG.md](https://github.com/boldlink/terraform-aws-iam-policy/blob/feature/add-external-arn/CHANGELOG.md#103---2022-07-21)

## Checklists:
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
### PR Owners Checklist:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you checked there aren't open [Pull Requests](../../../pulls) of upstream or parallel code that will cause conflicts?
* [x] Have you updated the `CHANGELOG.md`?
* [x] Have you updated the `README.md`(s)?
* [ ] OWNER: Does your submission pass?
    * [x] Pre-commit (attach logs/print screen to this PR)
    * [x] Checkov/terrascan (attach logs/print screen to this PR)
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
* [ ] First PR? Have you deleted `## How to use this template...` from the root `.README.md`?

### PR Reviewers Checklists?
* [ ] Are all your comments/changes resolved?
* [ ] Are you happy with the OWNER checklists and additional information provided?
* [ ] Does your review tests pass?
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
